### PR TITLE
Show indeterminate progress during ingestion and chunking

### DIFF
--- a/src/ui/app.py
+++ b/src/ui/app.py
@@ -72,14 +72,28 @@ def index() -> None:
         p: GenerationProgress = state["progress"]
         with ui.card().classes("w-full p-4"):
             ui.label(_phase_label(p)).classes("text-sm font-semibold text-primary")
-            ui.linear_progress(value=p.fraction, show_value=False).props(
-                "color=primary rounded"
-            ).classes("w-full")
-            detail = (
-                f"pages {p.total_pages} · "
-                f"chunks {p.chunks_done}/{p.total_chunks or '?'} · "
-                f"questions {len(p.quizzes)}"
-            )
+
+            if p.phase in ("ingesting", "chunking"):
+                ui.linear_progress(show_value=False).props(
+                    "indeterminate color=primary rounded"
+                ).classes("w-full")
+            else:
+                ui.linear_progress(value=p.fraction, show_value=False).props(
+                    "color=primary rounded"
+                ).classes("w-full")
+
+            if p.phase == "idle":
+                detail = "Ready"
+            elif p.phase == "ingesting":
+                detail = "Reading PDF…"
+            elif p.phase == "chunking":
+                detail = f"pages {p.total_pages} · Splitting into chunks…"
+            else:
+                detail = (
+                    f"pages {p.total_pages} · "
+                    f"chunks {p.chunks_done}/{p.total_chunks or '?'} · "
+                    f"questions {len(p.quizzes)}"
+                )
             ui.label(detail).classes("text-xs opacity-70")
             if p.phase == "error" and p.error:
                 ui.label(f"Error: {p.error}").classes("text-xs text-negative")

--- a/src/ui/app.py
+++ b/src/ui/app.py
@@ -83,11 +83,11 @@ def index() -> None:
                 ).classes("w-full")
 
             if p.phase == "idle":
-                detail = "Ready"
+                detail = ""
             elif p.phase == "ingesting":
-                detail = "Reading PDF…"
+                detail = "Preparing document..."
             elif p.phase == "chunking":
-                detail = f"pages {p.total_pages} · Splitting into chunks…"
+                detail = f"pages {p.total_pages}"
             else:
                 detail = (
                     f"pages {p.total_pages} · "

--- a/tests/test_ui_runner.py
+++ b/tests/test_ui_runner.py
@@ -83,6 +83,15 @@ async def test_run_generation_records_error(monkeypatch):
     assert "boom" in (snapshots[-1].error or "")
 
 
+def test_fraction_zero_when_total_chunks_unknown():
+    """fraction returns 0.0 when total_chunks is 0 (ingesting/chunking phases)."""
+    p = GenerationProgress(phase="ingesting", total_chunks=0, chunks_done=0)
+    assert p.fraction == 0.0
+
+    p = GenerationProgress(phase="chunking", total_pages=5, total_chunks=0)
+    assert p.fraction == 0.0
+
+
 @pytest.mark.asyncio
 async def test_run_generation_supports_async_callback(monkeypatch):
     """on_progress can be either sync or async; the runner awaits when needed."""


### PR DESCRIPTION
## Summary
- Switches progress bar to indeterminate/pulsing mode during `ingesting` and `chunking` phases so users see activity instead of a stuck 0% bar
- Shows phase-appropriate detail text instead of misleading `pages 0 · chunks 0/?` counters
- Transitions to a determinate bar once chunk count is known (`generating`, `aggregating`, `done`)
- Adds a unit test verifying `GenerationProgress.fraction` returns 0.0 when `total_chunks` is 0

Closes #5

## Test plan
- [ ] Upload a PDF and verify the progress bar pulses during ingestion
- [ ] Verify it transitions to a filling bar once chunks start processing
- [ ] Verify detail text is contextual per phase
- [ ] `uv run pytest` passes (9 tests, including the new one)