### PR TITLE
Stop refreshing quiz cards during generation to preserve edits

### DIFF
--- a/src/ui/app.py
+++ b/src/ui/app.py
@@ -210,7 +210,8 @@ def index() -> None:
 
         def push(snapshot: GenerationProgress) -> None:
             state["progress"] = snapshot
-            state["quizzes"] = [dict(q) for q in snapshot.quizzes]
+            if snapshot.phase in ("done", "error"):
+                state["quizzes"] = [dict(q) for q in snapshot.quizzes]
             progress_view.refresh()
 
         try:

--- a/src/ui/app.py
+++ b/src/ui/app.py
@@ -202,6 +202,7 @@ def index() -> None:
 
         state["running"] = True
         state["quizzes"] = []
+        state["page"] = 0
         state["progress"] = GenerationProgress(phase="ingesting")
         generate_btn.disable()
         progress_view.refresh()
@@ -210,9 +211,7 @@ def index() -> None:
         def push(snapshot: GenerationProgress) -> None:
             state["progress"] = snapshot
             state["quizzes"] = [dict(q) for q in snapshot.quizzes]
-            state["page"] = 0
             progress_view.refresh()
-            cards_view.refresh()
 
         try:
             await run_generation(state["pdf_path"], push)


### PR DESCRIPTION
## Summary
- Removes `cards_view.refresh()` from the `push()` callback during generation
- Cards are now rendered once at the start (empty) and once at the end (complete results)
- Progress bar continues to update live via `progress_view.refresh()`
- Moves `state["page"] = 0` reset to the start of `on_generate()` instead of repeating it on every progress snapshot

Closes #9

## Test plan
- [ ] Generate quizzes — cards appear only at the end
- [ ] Progress bar still updates live during generation
- [ ] Edit a quiz after generation — edits persist when navigating pages
- [ ] All existing tests pass