### PR TITLE
Validate uploaded files as real PDFs using magic bytes

### DIFF
--- a/src/ui/app.py
+++ b/src/ui/app.py
@@ -298,7 +298,7 @@ def index() -> None:
         suffix = Path(filename).suffix or ".pdf"
         tmp = tempfile.NamedTemporaryFile(delete=False, suffix=suffix)
         tmp.close()
-        Path(tmp.name).write_bytes(raw)
+        await e.file.save(tmp.name)
         state["pdf_path"] = tmp.name
         state["pdf_name"] = filename
         upload_status.set_text(f"Loaded: {filename}")

--- a/src/ui/app.py
+++ b/src/ui/app.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import math
 import tempfile
 from pathlib import Path
-from typing import Any
+from typing import IO, Any
 
 from nicegui import app, events, ui
 
@@ -21,6 +21,13 @@ PROVIDER_MODEL_FIELD = {
 GREEN_PRIMARY = "#16a34a"
 GREEN_DARK = "#15803d"
 GREEN_ACCENT = "#22c55e"
+
+
+def is_valid_pdf(content: IO[bytes]) -> bool:
+    """Check if file content starts with the PDF magic bytes."""
+    header = content.read(5)
+    content.seek(0)
+    return header == b"%PDF-"
 
 
 def _model_for(provider: str) -> str:
@@ -276,6 +283,13 @@ def index() -> None:
         cards_view.refresh()
 
     async def on_upload(e: events.UploadEventArguments) -> None:
+        from io import BytesIO
+
+        raw = await e.file.read()
+        if not is_valid_pdf(BytesIO(raw)):
+            ui.notify("Uploaded file is not a valid PDF.", type="warning")
+            return
+
         old_path = state["pdf_path"]
         if old_path:
             Path(old_path).unlink(missing_ok=True)
@@ -284,7 +298,7 @@ def index() -> None:
         suffix = Path(filename).suffix or ".pdf"
         tmp = tempfile.NamedTemporaryFile(delete=False, suffix=suffix)
         tmp.close()
-        await e.file.save(tmp.name)
+        Path(tmp.name).write_bytes(raw)
         state["pdf_path"] = tmp.name
         state["pdf_name"] = filename
         upload_status.set_text(f"Loaded: {filename}")

--- a/tests/test_upload_validation.py
+++ b/tests/test_upload_validation.py
@@ -1,0 +1,24 @@
+from io import BytesIO
+
+from src.ui.app import is_valid_pdf
+
+
+def test_valid_pdf_header():
+    content = BytesIO(b"%PDF-1.7 rest of content")
+    assert is_valid_pdf(content) is True
+    assert content.read(1) == b"%"  # verify seek(0) worked
+
+
+def test_invalid_header():
+    content = BytesIO(b"PK\x03\x04 this is a zip")
+    assert is_valid_pdf(content) is False
+
+
+def test_empty_file():
+    content = BytesIO(b"")
+    assert is_valid_pdf(content) is False
+
+
+def test_short_file():
+    content = BytesIO(b"%PD")
+    assert is_valid_pdf(content) is False


### PR DESCRIPTION
## Summary
- Adds server-side PDF validation by checking the `%PDF-` magic bytes header
- Rejects non-PDF files at upload time with a clear warning notification
- Extracts validation into a testable `is_valid_pdf()` helper

Closes #7

## Test plan
- [ ] Upload a valid PDF — accepted normally
- [ ] Upload a renamed .txt file — rejected with warning
- [ ] Upload an empty file — rejected with warning
- [ ] Unit tests for `is_valid_pdf()` pass