### PR TITLE
Add cancel button to abort in-progress generation

### DIFF
--- a/src/agent/graph.py
+++ b/src/agent/graph.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 from typing import Awaitable, Callable, Final, Literal, cast
 
@@ -267,6 +268,7 @@ async def graph_ainvoke(
     pdf_url_or_base64: str = "temp/sample.pdf",
     thread_id: str = f"qthread_{os.urandom(8).hex()}",
     on_update: Callable[[dict], Awaitable[None]] | None = None,
+    cancel_event: asyncio.Event | None = None,
 ) -> GlobalQuizState | StateSnapshot:
     initial_state: GlobalQuizState = GlobalQuizState(
         pdf_url_or_base64=pdf_url_or_base64,
@@ -296,6 +298,10 @@ async def graph_ainvoke(
         logger.info(f"Graph Update -  {summary}\n\n")
         if on_update is not None:
             await on_update(update)
+
+        if cancel_event is not None and cancel_event.is_set():
+            logger.info("Graph execution cancelled by user")
+            break
 
     final_state = await graph.aget_state(config=config)
 

--- a/src/ui/app.py
+++ b/src/ui/app.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import math
 import tempfile
 from pathlib import Path
@@ -61,6 +62,7 @@ def index() -> None:
         "concurrency": settings.GEN_CONCURRENCY,
         "page": 0,
         "page_size": 10,
+        "cancel_event": None,
     }
 
     # ============================================================
@@ -203,9 +205,11 @@ def index() -> None:
         state["running"] = True
         state["quizzes"] = []
         state["progress"] = GenerationProgress(phase="ingesting")
+        state["cancel_event"] = asyncio.Event()
         generate_btn.disable()
         progress_view.refresh()
         cards_view.refresh()
+        action_buttons.refresh()
 
         def push(snapshot: GenerationProgress) -> None:
             state["progress"] = snapshot
@@ -215,19 +219,31 @@ def index() -> None:
             cards_view.refresh()
 
         try:
-            await run_generation(state["pdf_path"], push)
-            ui.notify(
-                f"Generated {len(state['quizzes'])} questions",
-                type="positive",
+            await run_generation(
+                state["pdf_path"],
+                push,
+                cancel_event=state["cancel_event"],
             )
+            if state["cancel_event"] and state["cancel_event"].is_set():
+                ui.notify(
+                    f"Cancelled — kept {len(state['quizzes'])} questions",
+                    type="warning",
+                )
+            else:
+                ui.notify(
+                    f"Generated {len(state['quizzes'])} questions",
+                    type="positive",
+                )
         except Exception as exc:
             logger.exception("UI generation failed")
             ui.notify(f"Generation failed: {exc}", type="negative")
         finally:
             state["running"] = False
+            state["cancel_event"] = None
             generate_btn.enable()
             progress_view.refresh()
             cards_view.refresh()
+            action_buttons.refresh()
 
     def on_download() -> None:
         quizzes = state["quizzes"]
@@ -387,20 +403,31 @@ def index() -> None:
                     "text-xs opacity-50"
                 )
 
-            # --- generate / reset ---
-            with ui.row().classes("w-full gap-2"):
-                generate_btn = ui.button(
-                    "Generate Quiz",
-                    icon="play_arrow",
-                    on_click=on_generate,
-                ).props("color=primary unelevated")
-                generate_btn.disable()
+            # --- generate / reset / cancel ---
+            @ui.refreshable
+            def action_buttons() -> None:
+                with ui.row().classes("w-full gap-2"):
+                    if state["running"] and state["cancel_event"]:
+                        ui.button(
+                            "Cancel",
+                            icon="cancel",
+                            on_click=lambda: state["cancel_event"].set(),
+                        ).props("color=red unelevated")
+                    else:
+                        ui.button(
+                            "Reset",
+                            icon="refresh",
+                            on_click=reset_all,
+                        ).props("flat color=primary")
 
-                ui.button(
-                    "Reset",
-                    icon="refresh",
-                    on_click=reset_all,
-                ).props("flat color=primary")
+            generate_btn = ui.button(
+                "Generate Quiz",
+                icon="play_arrow",
+                on_click=on_generate,
+            ).props("color=primary unelevated")
+            generate_btn.disable()
+
+            action_buttons()
 
             # --- progress ---
             progress_view()

--- a/src/ui/runner.py
+++ b/src/ui/runner.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass, field
 from typing import Awaitable, Callable, Literal
 
@@ -36,11 +37,15 @@ OnProgress = Callable[[GenerationProgress], Awaitable[None] | None]
 async def run_generation(
     pdf_path: str,
     on_progress: OnProgress,
+    cancel_event: asyncio.Event | None = None,
 ) -> list[FinalQuizItem]:
     progress = GenerationProgress(phase="ingesting")
     await _emit(on_progress, progress)
 
+    cancelled = False
+
     async def on_update(update: dict) -> None:
+        nonlocal cancelled
         for node_name, node_update in update.items():
             if not isinstance(node_update, dict):
                 continue
@@ -66,10 +71,14 @@ async def run_generation(
 
         await _emit(on_progress, progress)
 
+        if cancel_event is not None and cancel_event.is_set():
+            cancelled = True
+
     try:
         result = await graph_ainvoke(
             pdf_url_or_base64=pdf_path,
             on_update=on_update,
+            cancel_event=cancel_event,
         )
     except Exception as exc:
         logger.exception("Generation failed")
@@ -77,6 +86,12 @@ async def run_generation(
         progress.error = str(exc)
         await _emit(on_progress, progress)
         raise
+
+    if cancelled:
+        logger.info("Generation cancelled by user")
+        progress.phase = "done"
+        await _emit(on_progress, progress)
+        return list(progress.quizzes)
 
     state_values = result.values if isinstance(result, StateSnapshot) else result
     final_quiz: list[FinalQuizItem] = list(state_values.get("final_quiz", []) or [])

--- a/src/ui/runner.py
+++ b/src/ui/runner.py
@@ -87,7 +87,7 @@ async def run_generation(
         await _emit(on_progress, progress)
         raise
 
-    if cancelled:
+    if cancelled or (cancel_event is not None and cancel_event.is_set()):
         logger.info("Generation cancelled by user")
         progress.phase = "done"
         await _emit(on_progress, progress)

--- a/tests/test_ui_runner.py
+++ b/tests/test_ui_runner.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 
 import pytest
@@ -36,6 +37,7 @@ async def test_run_generation_maps_updates_to_progress(monkeypatch):
         pdf_url_or_base64: str,
         thread_id: str | None = None,
         on_update=None,
+        cancel_event=None,
     ) -> Any:
         for update in fake_updates:
             if on_update is not None:
@@ -69,7 +71,7 @@ async def test_run_generation_maps_updates_to_progress(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_run_generation_records_error(monkeypatch):
-    async def fake_graph_ainvoke(*_args, **_kwargs):
+    async def fake_graph_ainvoke(*_args, cancel_event=None, **_kwargs):
         raise RuntimeError("boom")
 
     monkeypatch.setattr(runner_module, "graph_ainvoke", fake_graph_ainvoke)
@@ -87,7 +89,7 @@ async def test_run_generation_records_error(monkeypatch):
 async def test_run_generation_supports_async_callback(monkeypatch):
     """on_progress can be either sync or async; the runner awaits when needed."""
 
-    async def fake_graph_ainvoke(*_args, on_update=None, **_kwargs):
+    async def fake_graph_ainvoke(*_args, on_update=None, cancel_event=None, **_kwargs):
         if on_update is not None:
             await on_update({"page_ingestor": {"pdf_pages_data": [{}]}})
             await on_update({"chunking": {"crawled_chunks": [{}]}})
@@ -106,3 +108,59 @@ async def test_run_generation_supports_async_callback(monkeypatch):
 
     assert len(result) == 1
     assert snapshots[-1].phase == "done"
+
+
+@pytest.mark.asyncio
+async def test_run_generation_cancels_early(monkeypatch):
+    """When cancel_event is set, generation stops and returns partial results."""
+    cancel_event = asyncio.Event()
+
+    fake_updates = [
+        {"page_ingestor": {"pdf_pages_data": [{"page_number": i, "content": ""} for i in range(1, 4)]}},
+        {"chunking": {"crawled_chunks": [{}, {}, {}, {}]}},
+        {"subgraph_generator": {"final_quiz": [_quiz("c1", 1)]}},
+        # cancel_event will be set after the first subgraph update
+        {"subgraph_generator": {"final_quiz": [_quiz("c2", 2)]}},
+        {"subgraph_generator": {"final_quiz": [_quiz("c3", 3)]}},
+        {"subgraph_generator": {"final_quiz": [_quiz("c4", 4)]}},
+        {"aggregator": {"final_quiz": [_quiz("c1", 1), _quiz("c2", 2), _quiz("c3", 3), _quiz("c4", 4)]}},
+    ]
+
+    call_count = 0
+
+    async def fake_graph_ainvoke(
+        pdf_url_or_base64: str,
+        thread_id: str | None = None,
+        on_update=None,
+        cancel_event: asyncio.Event | None = None,
+    ) -> Any:
+        nonlocal call_count
+        for update in fake_updates:
+            if cancel_event is not None and cancel_event.is_set():
+                break
+            if on_update is not None:
+                await on_update(update)
+            call_count += 1
+            # Set cancel after first subgraph_generator update
+            if call_count == 3:
+                cancel_event.set()
+        return {"final_quiz": [_quiz("c1", 1)]}
+
+    monkeypatch.setattr(runner_module, "graph_ainvoke", fake_graph_ainvoke)
+
+    snapshots: list[GenerationProgress] = []
+
+    def push(snap: GenerationProgress) -> None:
+        snapshots.append(snap)
+
+    result = await run_generation("dummy.pdf", push, cancel_event=cancel_event)
+
+    # Should return partial results (only what was collected before cancellation)
+    assert len(result) >= 1
+    assert len(result) < 4  # not all 4 chunks completed
+
+    # Final snapshot should be "done"
+    assert snapshots[-1].phase == "done"
+
+    # The quizzes returned should match what was collected
+    assert len(result) == len(snapshots[-1].quizzes)


### PR DESCRIPTION
## Summary
- Adds `cancel_event` parameter to `run_generation()` and `graph_ainvoke()` for cooperative cancellation
- Adds a Cancel button in the UI, visible only during active generation (swaps with Reset button)
- Preserves already-generated quizzes on cancellation

Closes #6

## Test plan
- [ ] Upload a PDF and start generation, then click Cancel
- [ ] Verify generation stops and partial quizzes are preserved
- [ ] Verify Cancel button disappears after cancellation and Reset reappears
- [ ] New unit test `test_run_generation_cancels_early` passes