### PR TITLE
Pass generation config explicitly instead of mutating global settings

### DIFF
--- a/src/agent/graph.py
+++ b/src/agent/graph.py
@@ -83,7 +83,15 @@ async def chunking(state: GlobalQuizState) -> dict[str, list[ChunkData]]:
 
 def route_chunks_to_subgraph(state: GlobalQuizState) -> list[Send]:
     chunks = state.get("crawled_chunks", [])
-    return [Send("subgraph_generator", {"chunk": chunk}) for chunk in chunks]
+    provider = state.get("provider", "")
+    model_name = state.get("model_name", "")
+    return [
+        Send(
+            "subgraph_generator",
+            {"chunk": chunk, "provider": provider, "model_name": model_name},
+        )
+        for chunk in chunks
+    ]
 
 
 async def subgraph_generator(state: SubGraphState) -> dict[str, list[FinalQuizItem]]:
@@ -96,6 +104,8 @@ async def subgraph_generator(state: SubGraphState) -> dict[str, list[FinalQuizIt
         quiz=[],
         iter_count=0,
         is_quiz_relevant=False,
+        provider=state.get("provider", settings.MODEL_PROVIDER),
+        model_name=state.get("model_name", ""),
     )
     logger.info(
         f"firing up subgraph generator for chunk_id: {state['chunk'].get('chunk_id', 'unknown')}"
@@ -159,7 +169,11 @@ async def quiz_generator(state: SubGraphState) -> dict[str, list[FinalQuizItem]]
         )
         return {"quiz": []}
 
-    structured_llm = get_llm().with_structured_output(MultipleQuiz)
+    provider = state.get("provider") or None
+    model_name = state.get("model_name") or None
+    structured_llm = get_llm(provider=provider, model=model_name).with_structured_output(
+        MultipleQuiz
+    )
 
     generator_prompt = GENERATE_QUIZ_PROMPT.format(chunk=chunk_text)
     generator_response = await structured_llm.ainvoke(
@@ -221,7 +235,11 @@ async def quiz_reviewer(state: SubGraphState) -> dict[str, int | bool]:
             "is_quiz_relevant": False,
             "iter_count": state.get("iter_count", 0) + 1,
         }
-    structured_llm = get_llm().with_structured_output(ReviewedQuiz)
+    provider = state.get("provider") or None
+    model_name = state.get("model_name") or None
+    structured_llm = get_llm(provider=provider, model=model_name).with_structured_output(
+        ReviewedQuiz
+    )
 
     review_prompt = REVIEW_QUIZ_PROMPT.format(
         chunk=chunk_text,
@@ -265,21 +283,29 @@ async def should_regenerate_quiz(
 
 async def graph_ainvoke(
     pdf_url_or_base64: str = "temp/sample.pdf",
-    thread_id: str = f"qthread_{os.urandom(8).hex()}",
+    thread_id: str | None = None,
     on_update: Callable[[dict], Awaitable[None]] | None = None,
+    provider: str | None = None,
+    model_name: str | None = None,
+    concurrency: int | None = None,
 ) -> GlobalQuizState | StateSnapshot:
+    if thread_id is None:
+        thread_id = f"qthread_{os.urandom(8).hex()}"
+
     initial_state: GlobalQuizState = GlobalQuizState(
         pdf_url_or_base64=pdf_url_or_base64,
         pdf_pages_data=[],
         crawled_chunks=[],
         final_quiz=[],
+        provider=provider or settings.MODEL_PROVIDER,
+        model_name=model_name or "",
     )
 
     graph = await build_graph()
     config: RunnableConfig = {
         "configurable": {
             "thread_id": thread_id,
-            "max_concurrency": settings.GEN_CONCURRENCY,
+            "max_concurrency": concurrency or settings.GEN_CONCURRENCY,
         }
     }
 

--- a/src/agent/graph.py
+++ b/src/agent/graph.py
@@ -305,8 +305,8 @@ async def graph_ainvoke(
     config: RunnableConfig = {
         "configurable": {
             "thread_id": thread_id,
-            "max_concurrency": concurrency or settings.GEN_CONCURRENCY,
-        }
+        },
+        "max_concurrency": concurrency or settings.GEN_CONCURRENCY,
     }
 
     logger.info("--------🚦 graph execution stream started--------")

--- a/src/agent/llm.py
+++ b/src/agent/llm.py
@@ -7,29 +7,33 @@ from pydantic import SecretStr
 from ..core import logger, settings
 
 
-def get_llm(provider: str | None = None) -> BaseChatModel:
+def get_llm(
+    provider: str | None = None,
+    model: str | None = None,
+) -> BaseChatModel:
     """Build the LLM client for the active (or given) provider.
 
-    Reads the latest settings on every call so a runtime provider/model
-    switch (e.g. from the UI sidebar) takes effect on the next invocation.
+    When *provider* or *model* are supplied they take precedence over the
+    global ``settings`` values.  This allows callers (e.g. per-session UI
+    state) to choose a provider/model without mutating the shared singleton.
     """
     chosen = provider or settings.MODEL_PROVIDER
 
     if chosen == "google":
         return ChatGoogleGenerativeAI(
-            model=settings.GEMINI_MODEL,
+            model=model or settings.GEMINI_MODEL,
             api_key=SecretStr(settings.GEMINI_API_KEY),
             temperature=1.0,
         )
     if chosen == "groq":
         return ChatGroq(
-            model=settings.GROQ_MODEL,
+            model=model or settings.GROQ_MODEL,
             api_key=SecretStr(settings.GROQ_API_KEY),
             temperature=1.0,
         )
     if chosen == "openai":
         return ChatOpenAI(
-            model=settings.OPENAI_MODEL,
+            model=model or settings.OPENAI_MODEL,
             api_key=SecretStr(settings.OPENAI_API_KEY) if settings.OPENAI_API_KEY else None,
         )
     raise ValueError(f"Unsupported model provider: {chosen}")

--- a/src/agent/state.py
+++ b/src/agent/state.py
@@ -32,6 +32,8 @@ class GlobalQuizState(TypedDict):
     pdf_pages_data: list[PDFPageData]
     crawled_chunks: list[ChunkData]
     final_quiz: Annotated[list[FinalQuizItem], add]
+    provider: str
+    model_name: str
 
 
 class SubGraphState(TypedDict):
@@ -39,3 +41,5 @@ class SubGraphState(TypedDict):
     quiz: list[FinalQuizItem]
     iter_count: int
     is_quiz_relevant: bool
+    provider: str
+    model_name: str

--- a/src/ui/app.py
+++ b/src/ui/app.py
@@ -192,13 +192,7 @@ def index() -> None:
             ui.notify("Upload a PDF first", type="warning")
             return
 
-        provider = state["provider"]
-        settings.MODEL_PROVIDER = provider  # type: ignore[assignment]
-        model_field = PROVIDER_MODEL_FIELD[provider]
-        if state["model"]:
-            setattr(settings, model_field, state["model"])
-        settings.GEN_CONCURRENCY = int(state["concurrency"]) or 1
-        provider_chip.set_text(f"provider: {provider}")
+        provider_chip.set_text(f"provider: {state['provider']}")
 
         state["running"] = True
         state["quizzes"] = []
@@ -215,7 +209,13 @@ def index() -> None:
             cards_view.refresh()
 
         try:
-            await run_generation(state["pdf_path"], push)
+            await run_generation(
+                state["pdf_path"],
+                push,
+                provider=state["provider"],
+                model_name=state["model"],
+                concurrency=int(state["concurrency"]) or 1,
+            )
             ui.notify(
                 f"Generated {len(state['quizzes'])} questions",
                 type="positive",

--- a/src/ui/runner.py
+++ b/src/ui/runner.py
@@ -36,6 +36,9 @@ OnProgress = Callable[[GenerationProgress], Awaitable[None] | None]
 async def run_generation(
     pdf_path: str,
     on_progress: OnProgress,
+    provider: str | None = None,
+    model_name: str | None = None,
+    concurrency: int | None = None,
 ) -> list[FinalQuizItem]:
     progress = GenerationProgress(phase="ingesting")
     await _emit(on_progress, progress)
@@ -70,6 +73,9 @@ async def run_generation(
         result = await graph_ainvoke(
             pdf_url_or_base64=pdf_path,
             on_update=on_update,
+            provider=provider,
+            model_name=model_name,
+            concurrency=concurrency,
         )
     except Exception as exc:
         logger.exception("Generation failed")

--- a/tests/test_ui_runner.py
+++ b/tests/test_ui_runner.py
@@ -36,6 +36,9 @@ async def test_run_generation_maps_updates_to_progress(monkeypatch):
         pdf_url_or_base64: str,
         thread_id: str | None = None,
         on_update=None,
+        provider: str | None = None,
+        model_name: str | None = None,
+        concurrency: int | None = None,
     ) -> Any:
         for update in fake_updates:
             if on_update is not None:
@@ -69,7 +72,14 @@ async def test_run_generation_maps_updates_to_progress(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_run_generation_records_error(monkeypatch):
-    async def fake_graph_ainvoke(*_args, **_kwargs):
+    async def fake_graph_ainvoke(
+        *_args,
+        on_update=None,
+        provider=None,
+        model_name=None,
+        concurrency=None,
+        **_kwargs,
+    ):
         raise RuntimeError("boom")
 
     monkeypatch.setattr(runner_module, "graph_ainvoke", fake_graph_ainvoke)
@@ -87,7 +97,9 @@ async def test_run_generation_records_error(monkeypatch):
 async def test_run_generation_supports_async_callback(monkeypatch):
     """on_progress can be either sync or async; the runner awaits when needed."""
 
-    async def fake_graph_ainvoke(*_args, on_update=None, **_kwargs):
+    async def fake_graph_ainvoke(
+        *_args, on_update=None, provider=None, model_name=None, concurrency=None, **_kwargs
+    ):
         if on_update is not None:
             await on_update({"page_ingestor": {"pdf_pages_data": [{}]}})
             await on_update({"chunking": {"crawled_chunks": [{}]}})


### PR DESCRIPTION
## Summary
- Adds `provider`, `model_name`, `concurrency` parameters through `run_generation()` -> `graph_ainvoke()` -> graph state -> node functions -> `get_llm()`
- Removes the three `settings.*` mutation lines in `on_generate()` that caused cross-session interference
- `get_llm()` now accepts an optional explicit `model` parameter in addition to `provider`
- Adds `provider` and `model_name` fields to `GlobalQuizState` and `SubGraphState`, propagated via `Send()` payloads
- Fixes `thread_id` default arg evaluated at import time (now generated inside function body)
- Two concurrent browser sessions can now generate with different provider/model/concurrency settings without interference

Closes #8

## Test plan
- [ ] Generate with different providers in two browser tabs simultaneously
- [ ] Verify each tab uses its own provider/model settings
- [ ] All existing tests pass with updated signatures (`uv run pytest` -- 8 passed)