### PR TITLE
Short-circuit empty chunks to avoid wasting retry budget

### DIFF
--- a/src/agent/graph.py
+++ b/src/agent/graph.py
@@ -219,7 +219,7 @@ async def quiz_reviewer(state: SubGraphState) -> dict[str, int | bool]:
         )
         return {
             "is_quiz_relevant": False,
-            "iter_count": state.get("iter_count", 0) + 1,
+            "iter_count": MAX_SUBGRAPH_ITER,
         }
     structured_llm = get_llm().with_structured_output(ReviewedQuiz)
 
@@ -250,7 +250,7 @@ async def should_regenerate_quiz(
 ) -> Literal["regenerate", "completed"]:
     logger.trace(f"Quiz relevance: {state.get('is_quiz_relevant', False)}, ")
     if (
-        state.get("is_quiz_relevant", False) is False
+        not state.get("is_quiz_relevant", False)
         and state.get("iter_count", 0) < MAX_SUBGRAPH_ITER
     ):
         return "regenerate"

--- a/tests/test_empty_chunk.py
+++ b/tests/test_empty_chunk.py
@@ -1,0 +1,40 @@
+import pytest
+
+from src.agent.graph import MAX_SUBGRAPH_ITER, quiz_reviewer, should_regenerate_quiz
+
+
+async def test_reviewer_sets_max_iter_for_empty_quiz():
+    """When quiz is empty, reviewer should set iter_count to MAX_SUBGRAPH_ITER to skip retries."""
+    state = {
+        "chunk": {
+            "chunk_text": "",
+            "page_number": 1,
+            "chunk_id": "1_abc",
+        },
+        "quiz": [],
+        "iter_count": 0,
+        "is_quiz_relevant": False,
+    }
+    result = await quiz_reviewer(state)
+    assert result["iter_count"] == MAX_SUBGRAPH_ITER
+    assert result["is_quiz_relevant"] is False
+
+
+async def test_should_regenerate_completes_at_max_iter():
+    """When iter_count equals MAX_SUBGRAPH_ITER, should route to completed."""
+    state = {
+        "is_quiz_relevant": False,
+        "iter_count": MAX_SUBGRAPH_ITER,
+    }
+    result = await should_regenerate_quiz(state)
+    assert result == "completed"
+
+
+async def test_should_regenerate_uses_not_instead_of_is_false():
+    """Falsy values other than literal False should also route correctly."""
+    state = {
+        "is_quiz_relevant": 0,  # falsy but not False
+        "iter_count": 0,
+    }
+    result = await should_regenerate_quiz(state)
+    assert result == "regenerate"


### PR DESCRIPTION
## Summary
- When `quiz_reviewer` receives an empty quiz, it now sets `iter_count` to `MAX_SUBGRAPH_ITER` instead of incrementing by 1, causing immediate exit via `should_regenerate_quiz`
- Fixes `is False` identity check to `not` for safe falsiness comparison
- Empty chunks now produce exactly 1 generator call + 1 reviewer call instead of 6

Closes #11

## Test plan
- [ ] Generate from a PDF with some empty pages — no extra LLM calls wasted
- [ ] New unit tests for empty quiz handling pass
- [ ] All existing tests pass