### PR TITLE
Isolate on_update callback exceptions from the generation pipeline

### DIFF
--- a/src/agent/graph.py
+++ b/src/agent/graph.py
@@ -295,7 +295,10 @@ async def graph_ainvoke(
         }
         logger.info(f"Graph Update -  {summary}\n\n")
         if on_update is not None:
-            await on_update(update)
+            try:
+                await on_update(update)
+            except Exception as exc:
+                logger.warning(f"on_update callback error (ignored): {exc}")
 
     final_state = await graph.aget_state(config=config)
 

--- a/src/agent/graph.py
+++ b/src/agent/graph.py
@@ -297,8 +297,8 @@ async def graph_ainvoke(
         if on_update is not None:
             try:
                 await on_update(update)
-            except Exception as exc:
-                logger.warning(f"on_update callback error (ignored): {exc}")
+            except Exception:
+                logger.warning("on_update callback error (ignored)", exc_info=True)
 
     final_state = await graph.aget_state(config=config)
 

--- a/tests/test_graph_callback.py
+++ b/tests/test_graph_callback.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.agent import graph as graph_module
+from src.agent.graph import graph_ainvoke
+
+
+@pytest.mark.asyncio
+async def test_on_update_exception_does_not_abort_graph(monkeypatch):
+    """A raising on_update callback should be caught and logged, not propagated."""
+
+    fake_updates = [
+        {"page_ingestor": {"pdf_pages_data": []}},
+        {"chunking": {"crawled_chunks": []}},
+        {"aggregator": {"final_quiz": []}},
+    ]
+
+    fake_final_state = AsyncMock()
+    fake_final_state.values = {"final_quiz": []}
+
+    async def fake_astream(initial_state, *, config, stream_mode):
+        for update in fake_updates:
+            yield update
+
+    mock_graph = AsyncMock()
+    mock_graph.astream = fake_astream
+    mock_graph.aget_state = AsyncMock(return_value=fake_final_state)
+
+    async def fake_build_graph():
+        return mock_graph
+
+    monkeypatch.setattr(graph_module, "build_graph", fake_build_graph)
+
+    # on_update that always raises
+    async def exploding_callback(update):
+        raise RuntimeError("UI slot error")
+
+    # Should NOT raise despite the callback exploding on every update
+    result = await graph_ainvoke(
+        pdf_url_or_base64="test.pdf",
+        on_update=exploding_callback,
+    )
+    assert result is not None
+
+
+@pytest.mark.asyncio
+async def test_on_update_healthy_callback_still_receives_updates(monkeypatch):
+    """A well-behaved on_update callback should still receive every update."""
+
+    fake_updates = [
+        {"page_ingestor": {"pdf_pages_data": []}},
+        {"chunking": {"crawled_chunks": []}},
+        {"aggregator": {"final_quiz": []}},
+    ]
+
+    fake_final_state = AsyncMock()
+    fake_final_state.values = {"final_quiz": []}
+
+    async def fake_astream(initial_state, *, config, stream_mode):
+        for update in fake_updates:
+            yield update
+
+    mock_graph = AsyncMock()
+    mock_graph.astream = fake_astream
+    mock_graph.aget_state = AsyncMock(return_value=fake_final_state)
+
+    async def fake_build_graph():
+        return mock_graph
+
+    monkeypatch.setattr(graph_module, "build_graph", fake_build_graph)
+
+    received: list[dict] = []
+
+    async def good_callback(update):
+        received.append(update)
+
+    await graph_ainvoke(
+        pdf_url_or_base64="test.pdf",
+        on_update=good_callback,
+    )
+
+    assert len(received) == len(fake_updates)

--- a/tests/test_graph_callback.py
+++ b/tests/test_graph_callback.py
@@ -43,7 +43,7 @@ async def test_on_update_exception_does_not_abort_graph(monkeypatch):
         pdf_url_or_base64="test.pdf",
         on_update=exploding_callback,
     )
-    assert result is not None
+    assert result == fake_final_state
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Wraps `await on_update(update)` in try/except in `graph_ainvoke()`
- Callback failures are logged as warnings but no longer abort the pipeline
- The graph continues streaming and produces its final state normally

Closes #12

## Test plan
- [ ] Generation works normally with a healthy UI callback
- [ ] If the UI callback fails, generation still completes (verified via test)
- [ ] Warning is logged when callback raises
- [ ] All existing tests pass