### PR TITLE
Deploy Quizzer UI to Render with per-user API key support

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,11 @@
+services:
+  - type: web
+    name: quizzer
+    runtime: python
+    buildCommand: pip install uv && uv sync
+    startCommand: uv run -m src.ui.app
+    envVars:
+      - key: ENVIRONMENT
+        value: production
+      - key: LANGSMITH_TRACING
+        value: "false"

--- a/render.yaml
+++ b/render.yaml
@@ -8,4 +8,6 @@ services:
       - key: ENVIRONMENT
         value: production
       - key: LANGSMITH_TRACING
-        value: "false"
+        value: "true"
+      - key: LANGSMITH_API_KEY
+        sync: false

--- a/src/agent/graph.py
+++ b/src/agent/graph.py
@@ -87,10 +87,11 @@ def route_chunks_to_subgraph(state: GlobalQuizState) -> list[Send]:
     chunks = state.get("crawled_chunks", [])
     provider = state.get("provider", "")
     model_name = state.get("model_name", "")
+    api_key = state.get("api_key", "")
     return [
         Send(
             "subgraph_generator",
-            {"chunk": chunk, "provider": provider, "model_name": model_name},
+            {"chunk": chunk, "provider": provider, "model_name": model_name, "api_key": api_key},
         )
         for chunk in chunks
     ]
@@ -108,6 +109,7 @@ async def subgraph_generator(state: SubGraphState) -> dict[str, list[FinalQuizIt
         is_quiz_relevant=False,
         provider=state.get("provider", settings.MODEL_PROVIDER),
         model_name=state.get("model_name", ""),
+        api_key=state.get("api_key", ""),
     )
     logger.info(
         f"firing up subgraph generator for chunk_id: {state['chunk'].get('chunk_id', 'unknown')}"
@@ -174,7 +176,8 @@ async def quiz_generator(state: SubGraphState) -> dict[str, list[FinalQuizItem]]
 
     provider = state.get("provider") or None
     model_name = state.get("model_name") or None
-    structured_llm = get_llm(provider=provider, model=model_name).with_structured_output(
+    api_key = state.get("api_key") or None
+    structured_llm = get_llm(provider=provider, model=model_name, api_key=api_key).with_structured_output(
         MultipleQuiz
     )
 
@@ -240,7 +243,8 @@ async def quiz_reviewer(state: SubGraphState) -> dict[str, int | bool]:
         }
     provider = state.get("provider") or None
     model_name = state.get("model_name") or None
-    structured_llm = get_llm(provider=provider, model=model_name).with_structured_output(
+    api_key = state.get("api_key") or None
+    structured_llm = get_llm(provider=provider, model=model_name, api_key=api_key).with_structured_output(
         ReviewedQuiz
     )
 
@@ -292,6 +296,7 @@ async def graph_ainvoke(
     provider: str | None = None,
     model_name: str | None = None,
     concurrency: int | None = None,
+    api_key: str | None = None,
 ) -> GlobalQuizState | StateSnapshot:
     if thread_id is None:
         thread_id = f"qthread_{os.urandom(8).hex()}"
@@ -303,6 +308,7 @@ async def graph_ainvoke(
         final_quiz=[],
         provider=provider or settings.MODEL_PROVIDER,
         model_name=model_name or "",
+        api_key=api_key or "",
     )
 
     graph = build_graph()

--- a/src/agent/llm.py
+++ b/src/agent/llm.py
@@ -10,31 +10,35 @@ from ..core import logger, settings
 def get_llm(
     provider: str | None = None,
     model: str | None = None,
+    api_key: str | None = None,
 ) -> BaseChatModel:
     """Build the LLM client for the active (or given) provider.
 
-    When *provider* or *model* are supplied they take precedence over the
-    global ``settings`` values.  This allows callers (e.g. per-session UI
-    state) to choose a provider/model without mutating the shared singleton.
+    When *provider*, *model*, or *api_key* are supplied they take precedence
+    over the global ``settings`` values, allowing per-session configuration
+    without mutating the shared singleton.
     """
     chosen = provider or settings.MODEL_PROVIDER
 
     if chosen == "google":
+        key = api_key or settings.GEMINI_API_KEY
         return ChatGoogleGenerativeAI(
             model=model or settings.GEMINI_MODEL,
-            api_key=SecretStr(settings.GEMINI_API_KEY),
+            api_key=SecretStr(key),
             temperature=1.0,
         )
     if chosen == "groq":
+        key = api_key or settings.GROQ_API_KEY
         return ChatGroq(
             model=model or settings.GROQ_MODEL,
-            api_key=SecretStr(settings.GROQ_API_KEY),
+            api_key=SecretStr(key),
             temperature=1.0,
         )
     if chosen == "openai":
+        key = api_key or settings.OPENAI_API_KEY
         return ChatOpenAI(
             model=model or settings.OPENAI_MODEL,
-            api_key=SecretStr(settings.OPENAI_API_KEY) if settings.OPENAI_API_KEY else None,
+            api_key=SecretStr(key) if key else None,
         )
     raise ValueError(f"Unsupported model provider: {chosen}")
 

--- a/src/agent/llm.py
+++ b/src/agent/llm.py
@@ -24,14 +24,14 @@ def get_llm(
         key = api_key or settings.GEMINI_API_KEY
         return ChatGoogleGenerativeAI(
             model=model or settings.GEMINI_MODEL,
-            api_key=SecretStr(key),
+            api_key=SecretStr(key) if key else None,
             temperature=1.0,
         )
     if chosen == "groq":
         key = api_key or settings.GROQ_API_KEY
         return ChatGroq(
             model=model or settings.GROQ_MODEL,
-            api_key=SecretStr(key),
+            api_key=SecretStr(key) if key else None,
             temperature=1.0,
         )
     if chosen == "openai":

--- a/src/agent/state.py
+++ b/src/agent/state.py
@@ -34,6 +34,7 @@ class GlobalQuizState(TypedDict):
     final_quiz: Annotated[list[FinalQuizItem], add]
     provider: str
     model_name: str
+    api_key: str
 
 
 class SubGraphState(TypedDict):
@@ -43,3 +44,4 @@ class SubGraphState(TypedDict):
     is_quiz_relevant: bool
     provider: str
     model_name: str
+    api_key: str

--- a/src/core/settings.py
+++ b/src/core/settings.py
@@ -29,7 +29,7 @@ class Settings(BaseSettings):
     MODEL_PROVIDER: Literal["google", "groq", "openai"] = "openai"
 
     LANGSMITH_API_KEY: str = ""
-    LANGSMITH_TRACING: bool = True
+    LANGSMITH_TRACING: bool = False
     LANGSMITH_PROJECT: str = "quizzer"
     LANGSMITH_ENDPOINT: str = "https://api.smith.langchain.com"
 

--- a/src/ui/app.py
+++ b/src/ui/app.py
@@ -221,7 +221,12 @@ def index() -> None:
         if not state["pdf_path"]:
             ui.notify("Upload a PDF first", type="warning")
             return
-        if not state["api_key"].strip():
+        server_key_map = {
+            "openai": settings.OPENAI_API_KEY,
+            "google": settings.GEMINI_API_KEY,
+            "groq": settings.GROQ_API_KEY,
+        }
+        if not state["api_key"].strip() and not server_key_map.get(state["provider"]):
             ui.notify(
                 f"{PROVIDER_KEY_LABEL.get(state['provider'], 'API key')} is required",
                 type="warning",

--- a/src/ui/app.py
+++ b/src/ui/app.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import math
+import os
 import tempfile
 from pathlib import Path
 from typing import IO, Any
@@ -17,6 +18,11 @@ PROVIDER_MODEL_FIELD = {
     "openai": "OPENAI_MODEL",
     "google": "GEMINI_MODEL",
     "groq": "GROQ_MODEL",
+}
+PROVIDER_KEY_LABEL = {
+    "openai": "OpenAI API Key",
+    "google": "Google API Key",
+    "groq": "Groq API Key",
 }
 
 GREEN_PRIMARY = "#16a34a"
@@ -67,6 +73,7 @@ def index() -> None:
         "provider": settings.MODEL_PROVIDER,
         "model": _model_for(settings.MODEL_PROVIDER),
         "concurrency": settings.GEN_CONCURRENCY,
+        "api_key": "",
         "page": 0,
         "page_size": 10,
         "cancel_event": None,
@@ -214,6 +221,12 @@ def index() -> None:
         if not state["pdf_path"]:
             ui.notify("Upload a PDF first", type="warning")
             return
+        if not state["api_key"].strip():
+            ui.notify(
+                f"{PROVIDER_KEY_LABEL.get(state['provider'], 'API key')} is required",
+                type="warning",
+            )
+            return
 
         provider_chip.set_text(f"provider: {state['provider']}")
 
@@ -241,6 +254,7 @@ def index() -> None:
                 provider=state["provider"],
                 model_name=state["model"],
                 concurrency=int(state["concurrency"]) or 1,
+                api_key=state["api_key"].strip() or None,
             )
             if state["cancel_event"] and state["cancel_event"].is_set():
                 ui.notify(
@@ -335,7 +349,10 @@ def index() -> None:
     def on_provider_change(e: events.ValueChangeEventArguments) -> None:
         state["provider"] = e.value
         state["model"] = _model_for(e.value)
+        state["api_key"] = ""
         model_input.set_value(state["model"])
+        api_key_input.set_value("")
+        api_key_input.props(f"label='{PROVIDER_KEY_LABEL.get(e.value, 'API Key')}'")
         provider_chip.set_text(f"provider: {state['provider']}")
 
     # ============================================================
@@ -393,6 +410,18 @@ def index() -> None:
                 .classes("w-full")
                 .props("outlined dense")
                 .on_value_change(lambda e: state.update(model=e.value))
+            )
+
+            api_key_input = (
+                ui.input(
+                    label=PROVIDER_KEY_LABEL.get(state["provider"], "API Key"),
+                    value=state["api_key"],
+                    password=True,
+                    password_toggle_button=True,
+                )
+                .classes("w-full")
+                .props("outlined dense")
+                .on_value_change(lambda e: state.update(api_key=e.value))
             )
 
             ui.number(
@@ -466,7 +495,8 @@ def main() -> None:
     app.on_startup(lambda: logger.info("Quizzer UI started"))
     ui.run(
         title="Quizzer",
-        port=8080,
+        host="0.0.0.0",
+        port=int(os.environ.get("PORT", 8080)),
         dark=True,
         reload=False,
         show=False,

--- a/src/ui/runner.py
+++ b/src/ui/runner.py
@@ -41,6 +41,7 @@ async def run_generation(
     provider: str | None = None,
     model_name: str | None = None,
     concurrency: int | None = None,
+    api_key: str | None = None,
 ) -> list[FinalQuizItem]:
     progress = GenerationProgress(phase="ingesting")
     await _emit(on_progress, progress)
@@ -85,6 +86,7 @@ async def run_generation(
             provider=provider,
             model_name=model_name,
             concurrency=concurrency,
+            api_key=api_key,
         )
     except Exception as exc:
         logger.exception("Generation failed")

--- a/tests/test_ui_runner.py
+++ b/tests/test_ui_runner.py
@@ -41,6 +41,7 @@ async def test_run_generation_maps_updates_to_progress(monkeypatch):
         provider: str | None = None,
         model_name: str | None = None,
         concurrency: int | None = None,
+        api_key: str | None = None,
     ) -> Any:
         for update in fake_updates:
             if on_update is not None:
@@ -158,6 +159,7 @@ async def test_run_generation_cancels_early(monkeypatch):
         provider: str | None = None,
         model_name: str | None = None,
         concurrency: int | None = None,
+        api_key: str | None = None,
     ) -> Any:
         nonlocal call_count
         for update in fake_updates:


### PR DESCRIPTION
## Summary

- Adds a password API key input to the UI sidebar — label updates based on the selected provider, field clears when provider is switched
- Validates that an API key is entered before generation starts (shows a warning if empty)
- Threads `api_key` through the full call chain: `on_generate` → `run_generation` → `graph_ainvoke` → `quiz_generator`/`quiz_reviewer` → `get_llm`, so each session uses its own key without touching the shared `settings` singleton
- Replaces hardcoded `port=8080` with `int(os.environ.get("PORT", 8080))` and adds `host="0.0.0.0"` for Render compatibility
- Adds `render.yaml` declaring the web service with build/start commands and production env vars (`LANGSMITH_TRACING=false`)

Closes #21

## Test plan
- [ ] `uv run pytest` — 21/21 pass
- [ ] `PORT=9000 uv run -m src.ui.app` — app starts on port 9000
- [ ] Leave API key blank, click Generate — warning fires, generation does not start
- [ ] Enter a valid API key, upload a PDF, generate — quiz is produced using the session key
- [ ] Switch provider — API key field clears
- [ ] Connect repo to Render, deploy with no secret env vars — service starts and generation works