### PR TITLE
Live token usage counter in the generation progress card

### DIFF
--- a/src/agent/graph.py
+++ b/src/agent/graph.py
@@ -297,6 +297,7 @@ async def graph_ainvoke(
     model_name: str | None = None,
     concurrency: int | None = None,
     api_key: str | None = None,
+    callbacks: list | None = None,
 ) -> GlobalQuizState | StateSnapshot:
     if thread_id is None:
         thread_id = f"qthread_{os.urandom(8).hex()}"
@@ -317,6 +318,7 @@ async def graph_ainvoke(
             "thread_id": thread_id,
         },
         "max_concurrency": concurrency or settings.GEN_CONCURRENCY,
+        "callbacks": callbacks or [],
     }
 
     logger.info("--------🚦 graph execution stream started--------")

--- a/src/ui/app.py
+++ b/src/ui/app.py
@@ -105,10 +105,12 @@ def index() -> None:
             elif p.phase == "chunking":
                 detail = f"pages {p.total_pages}"
             else:
+                token_part = f" · tokens {p.total_tokens:,}" if p.total_tokens else ""
                 detail = (
                     f"pages {p.total_pages} · "
                     f"chunks {p.chunks_done}/{p.total_chunks or '?'} · "
                     f"questions {len(p.quizzes)}"
+                    f"{token_part}"
                 )
             ui.label(detail).classes("text-xs opacity-70")
             if p.phase == "error" and p.error:

--- a/src/ui/runner.py
+++ b/src/ui/runner.py
@@ -22,17 +22,24 @@ class TokenCounterCallback(AsyncCallbackHandler):
         self.total_tokens: int = 0
 
     async def on_llm_end(self, response: LLMResult, **kwargs: object) -> None:
-        for gen_list in response.generations:
-            for gen in gen_list:
-                msg = getattr(gen, "message", None)
-                usage = getattr(msg, "usage_metadata", None) if msg else None
-                if usage:
+        try:
+            found = False
+            for gen_list in response.generations:
+                for gen in gen_list:
+                    msg = getattr(gen, "message", None)
+                    usage = getattr(msg, "usage_metadata", None) if msg else None
+                    if isinstance(usage, dict) and usage.get("total_tokens"):
+                        self.total_tokens += usage["total_tokens"]
+                        found = True
+                        break
+                if found:
+                    break
+            if not found and response.llm_output:
+                usage = response.llm_output.get("token_usage", {})
+                if isinstance(usage, dict):
                     self.total_tokens += usage.get("total_tokens", 0)
-                    return
-        # provider-specific fallback
-        if response.llm_output:
-            usage = response.llm_output.get("token_usage", {})
-            self.total_tokens += usage.get("total_tokens", 0)
+        except Exception:
+            pass
 
 
 @dataclass

--- a/src/ui/runner.py
+++ b/src/ui/runner.py
@@ -4,6 +4,8 @@ import asyncio
 from dataclasses import dataclass, field
 from typing import Awaitable, Callable, Literal
 
+from langchain_core.callbacks import AsyncCallbackHandler
+from langchain_core.outputs import LLMResult
 from langgraph.types import StateSnapshot
 
 from ..agent.graph import graph_ainvoke
@@ -15,6 +17,24 @@ Phase = Literal[
 ]
 
 
+class TokenCounterCallback(AsyncCallbackHandler):
+    def __init__(self) -> None:
+        self.total_tokens: int = 0
+
+    async def on_llm_end(self, response: LLMResult, **kwargs: object) -> None:
+        for gen_list in response.generations:
+            for gen in gen_list:
+                msg = getattr(gen, "message", None)
+                usage = getattr(msg, "usage_metadata", None) if msg else None
+                if usage:
+                    self.total_tokens += usage.get("total_tokens", 0)
+                    return
+        # provider-specific fallback
+        if response.llm_output:
+            usage = response.llm_output.get("token_usage", {})
+            self.total_tokens += usage.get("total_tokens", 0)
+
+
 @dataclass
 class GenerationProgress:
     phase: Phase = "idle"
@@ -23,6 +43,7 @@ class GenerationProgress:
     chunks_done: int = 0
     quizzes: list[FinalQuizItem] = field(default_factory=list)
     error: str | None = None
+    total_tokens: int = 0
 
     @property
     def fraction(self) -> float:
@@ -43,6 +64,7 @@ async def run_generation(
     concurrency: int | None = None,
     api_key: str | None = None,
 ) -> list[FinalQuizItem]:
+    token_counter = TokenCounterCallback()
     progress = GenerationProgress(phase="ingesting")
     await _emit(on_progress, progress)
 
@@ -73,6 +95,7 @@ async def run_generation(
             elif node_name == "aggregator":
                 progress.phase = "aggregating"
 
+        progress.total_tokens = token_counter.total_tokens
         await _emit(on_progress, progress)
 
         if cancel_event is not None and cancel_event.is_set():
@@ -87,6 +110,7 @@ async def run_generation(
             model_name=model_name,
             concurrency=concurrency,
             api_key=api_key,
+            callbacks=[token_counter],
         )
     except Exception as exc:
         logger.exception("Generation failed")
@@ -105,6 +129,7 @@ async def run_generation(
     final_quiz: list[FinalQuizItem] = list(state_values.get("final_quiz", []) or [])
 
     progress.quizzes = final_quiz
+    progress.total_tokens = token_counter.total_tokens
     if progress.total_chunks:
         progress.chunks_done = progress.total_chunks
     progress.phase = "done"
@@ -121,6 +146,7 @@ async def _emit(on_progress: OnProgress, progress: GenerationProgress) -> None:
         chunks_done=progress.chunks_done,
         quizzes=list(progress.quizzes),
         error=progress.error,
+        total_tokens=progress.total_tokens,
     )
     result = on_progress(snapshot)
     if result is not None:

--- a/tests/test_ui_runner.py
+++ b/tests/test_ui_runner.py
@@ -42,6 +42,7 @@ async def test_run_generation_maps_updates_to_progress(monkeypatch):
         model_name: str | None = None,
         concurrency: int | None = None,
         api_key: str | None = None,
+        callbacks: list | None = None,
     ) -> Any:
         for update in fake_updates:
             if on_update is not None:
@@ -160,6 +161,7 @@ async def test_run_generation_cancels_early(monkeypatch):
         model_name: str | None = None,
         concurrency: int | None = None,
         api_key: str | None = None,
+        callbacks: list | None = None,
     ) -> Any:
         nonlocal call_count
         for update in fake_updates:


### PR DESCRIPTION
Closes #25

## Summary

- Adds `TokenCounterCallback` (a LangChain `AsyncCallbackHandler`) that accumulates token counts via `on_llm_end` — fires after every LLM call without touching node functions or state TypedDicts.
- Passes the callback in the LangGraph `RunnableConfig` via a new `callbacks` param on `graph_ainvoke`.
- Adds `total_tokens: int = 0` to `GenerationProgress` and syncs it from the counter on every `on_update` tick (real-time updates).
- Extends the progress card detail line to show `· tokens N,NNN` once non-zero.

**Known tradeoff:** Google (Gemini) may undercount mid-run and correct itself at the end due to inconsistent callback reporting. OpenAI and Groq are reliable. Accepted.

## Test plan

- [ ] `uv run pytest` passes (21/21)
- [ ] Run the UI with a real PDF + API key — confirm token count appears in the progress card and increments as chunks complete
- [ ] Confirm final token count persists on the "Done" phase