### PR TITLE
"Get a free API key" link for Groq in the sidebar

### DIFF
--- a/src/ui/app.py
+++ b/src/ui/app.py
@@ -24,6 +24,11 @@ PROVIDER_KEY_LABEL = {
     "google": "Google API Key",
     "groq": "Groq API Key",
 }
+PROVIDER_KEY_URL = {
+    "openai": "https://platform.openai.com/api-keys",
+    "google": "https://aistudio.google.com/apikey",
+    "groq": "https://console.groq.com/keys",
+}
 
 GREEN_PRIMARY = "#16a34a"
 GREEN_DARK = "#15803d"
@@ -359,7 +364,8 @@ def index() -> None:
         api_key_input.set_value("")
         api_key_input.props(f"label='{PROVIDER_KEY_LABEL.get(e.value, 'API Key')}'")
         provider_chip.set_text(f"provider: {state['provider']}")
-        free_key_link.set_visibility(e.value == "groq")
+        for provider, link in key_links.items():
+            link.set_visibility(provider == e.value)
 
     # ============================================================
     # UI build
@@ -427,11 +433,15 @@ def index() -> None:
                 .on_value_change(lambda e: state.update(api_key=e.value))
             )
 
-            free_key_link = (
-                ui.link("Get a free API key →", "https://console.groq.com/keys", new_tab=True)
-                .classes("text-xs text-primary")
-            )
-            free_key_link.set_visibility(state["provider"] == "groq")
+            key_links = {
+                provider: (
+                    ui.link("Get an API key →", PROVIDER_KEY_URL[provider], new_tab=True)
+                    .classes("text-xs text-primary")
+                )
+                for provider in PROVIDERS
+            }
+            for provider, link in key_links.items():
+                link.set_visibility(provider == state["provider"])
 
             ui.number(
                 label="Concurrency",

--- a/src/ui/app.py
+++ b/src/ui/app.py
@@ -359,6 +359,7 @@ def index() -> None:
         api_key_input.set_value("")
         api_key_input.props(f"label='{PROVIDER_KEY_LABEL.get(e.value, 'API Key')}'")
         provider_chip.set_text(f"provider: {state['provider']}")
+        free_key_link.set_visibility(e.value == "groq")
 
     # ============================================================
     # UI build
@@ -425,6 +426,12 @@ def index() -> None:
                 .props("outlined dense")
                 .on_value_change(lambda e: state.update(api_key=e.value))
             )
+
+            free_key_link = (
+                ui.link("Get a free API key →", "https://console.groq.com/keys", new_tab=True)
+                .classes("text-xs text-primary")
+            )
+            free_key_link.set_visibility(state["provider"] == "groq")
 
             ui.number(
                 label="Concurrency",

--- a/src/ui/app.py
+++ b/src/ui/app.py
@@ -421,27 +421,28 @@ def index() -> None:
                 .on_value_change(lambda e: state.update(model=e.value))
             )
 
-            api_key_input = (
-                ui.input(
-                    label=PROVIDER_KEY_LABEL.get(state["provider"], "API Key"),
-                    value=state["api_key"],
-                    password=True,
-                    password_toggle_button=True,
+            with ui.column().classes("w-full gap-1"):
+                api_key_input = (
+                    ui.input(
+                        label=PROVIDER_KEY_LABEL.get(state["provider"], "API Key"),
+                        value=state["api_key"],
+                        password=True,
+                        password_toggle_button=True,
+                    )
+                    .classes("w-full")
+                    .props("outlined dense")
+                    .on_value_change(lambda e: state.update(api_key=e.value))
                 )
-                .classes("w-full")
-                .props("outlined dense")
-                .on_value_change(lambda e: state.update(api_key=e.value))
-            )
 
-            key_links = {
-                provider: (
-                    ui.link("Get an API key →", PROVIDER_KEY_URL[provider], new_tab=True)
-                    .classes("text-xs text-primary")
-                )
-                for provider in PROVIDERS
-            }
-            for provider, link in key_links.items():
-                link.set_visibility(provider == state["provider"])
+                key_links = {
+                    provider: (
+                        ui.link("Get an API key →", PROVIDER_KEY_URL[provider], new_tab=True)
+                        .classes("text-xs text-primary")
+                    )
+                    for provider in PROVIDERS
+                }
+                for provider, link in key_links.items():
+                    link.set_visibility(provider == state["provider"])
 
             ui.number(
                 label="Concurrency",


### PR DESCRIPTION
Closes #26

## Summary

- Adds a `ui.link` ("Get a free API key →") pointing to `https://console.groq.com/keys` beneath the API key input in the sidebar.
- Visible only when Groq is the selected provider; hidden for OpenAI and Google.
- Toggled via `free_key_link.set_visibility(e.value == "groq")` in the existing `on_provider_change` handler.

## Test plan

- [ ] `uv run pytest` passes (21/21)
- [ ] Select **Groq** in the provider dropdown → link appears below the API key field
- [ ] Switch to **OpenAI** or **Google** → link disappears
- [ ] Link opens `console.groq.com/keys` in a new tab