### PR TITLE
UI redesign: quiz mode, card improvements, and progress panel cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ logs/
 temp/
 .claude/
 .hallmark/
+.nicegui/

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ logs/
 .env.test
 temp/
 .claude/
+.hallmark/

--- a/src/ui/app.py
+++ b/src/ui/app.py
@@ -159,6 +159,43 @@ body, .q-app { font-family: var(--font-ui) !important; }
   display: flex; flex-direction: column; align-items: center;
   gap: 8px; padding: 48px 24px; text-align: center; opacity: 0.5;
 }
+
+/* ── Quiz card ──────────────────────────────── */
+.qz-q-number {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 28px; height: 28px; border-radius: 50%;
+  background: var(--q-primary, #16a34a); color: #fff;
+  font-size: 11px; font-weight: 800; font-family: var(--font-ui); flex-shrink: 0;
+}
+.qz-page-chip {
+  display: inline-flex; align-items: center;
+  padding: 2px 8px; border-radius: 999px;
+  font-size: 11px; font-weight: 600; font-family: var(--font-ui);
+}
+.body--dark .qz-page-chip  { background: oklch(28% 0.010 142); color: oklch(62% 0.010 142); }
+.body--light .qz-page-chip { background: oklch(88% 0.012 142); color: oklch(40% 0.010 142); }
+
+.qz-options-label {
+  font-size: 10px; font-weight: 700; letter-spacing: 0.08em;
+  text-transform: uppercase; font-family: var(--font-ui); margin-bottom: 2px;
+}
+.body--dark .qz-options-label  { color: oklch(52% 0.008 142); }
+.body--light .qz-options-label { color: oklch(45% 0.008 142); }
+
+.qz-option-letter {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 26px; height: 26px; border-radius: 7px;
+  font-size: 11px; font-weight: 700; font-family: var(--font-ui); flex-shrink: 0;
+}
+.body--dark .qz-option-letter  { background: oklch(27% 0.010 142); color: oklch(62% 0.010 142); }
+.body--light .qz-option-letter { background: oklch(89% 0.012 142); color: oklch(38% 0.010 142); }
+
+.qz-answer-label {
+  font-size: 10px; font-weight: 700; letter-spacing: 0.07em;
+  text-transform: uppercase; font-family: var(--font-ui);
+}
+.body--dark .qz-answer-label  { color: oklch(52% 0.008 142); }
+.body--light .qz-answer-label { color: oklch(45% 0.008 142); }
 </style>
 """
 
@@ -270,7 +307,9 @@ def index() -> None:
     def cards_view() -> None:
         quizzes: list[dict] = state["quizzes"]
         with ui.row().classes("w-full items-center justify-between"):
-            ui.html(f'<div class="qz-step-row" style="margin-bottom:0"><span class="qz-step-badge">3</span><span class="qz-step-label">Review &amp; Download ({len(quizzes)})</span></div>')
+            ui.html(
+                f'<div class="qz-step-row" style="margin-bottom:0"><span class="qz-step-badge">3</span><span class="qz-step-label">Review &amp; Download ({len(quizzes)})</span></div>'
+            )
             download_btn = ui.button(
                 "Download CSV",
                 icon="download",
@@ -283,7 +322,9 @@ def index() -> None:
             with ui.column().classes("qz-empty w-full"):
                 ui.icon("auto_stories").classes("text-5xl")
                 ui.label("No questions yet").classes("text-sm font-semibold")
-                ui.label("Upload a PDF and hit Generate to get started.").classes("text-xs")
+                ui.label("Upload a PDF and hit Generate to get started.").classes(
+                    "text-xs"
+                )
             return
 
         page = state["page"]
@@ -299,7 +340,10 @@ def index() -> None:
             with ui.row().classes("w-full items-center justify-center gap-4 mt-2"):
                 ui.button(
                     icon="chevron_left",
-                    on_click=lambda: (state.update(page=state["page"] - 1), cards_view.refresh()),
+                    on_click=lambda: (
+                        state.update(page=state["page"] - 1),
+                        cards_view.refresh(),
+                    ),
                 ).props("flat dense round color=primary").bind_enabled_from(
                     state, "page", backward=lambda p: p > 0
                 )
@@ -308,59 +352,83 @@ def index() -> None:
                 )
                 ui.button(
                     icon="chevron_right",
-                    on_click=lambda: (state.update(page=state["page"] + 1), cards_view.refresh()),
+                    on_click=lambda: (
+                        state.update(page=state["page"] + 1),
+                        cards_view.refresh(),
+                    ),
                 ).props("flat dense round color=primary").bind_enabled_from(
                     state, "page", backward=lambda p: p < total_pages - 1
                 )
 
     def _quiz_card(idx: int, quiz: dict) -> None:
-        with ui.card().classes("w-full p-4 gap-2"):
-            with ui.row().classes("w-full items-center justify-between"):
-                ui.label(f"Q{idx + 1}").classes(
-                    "text-xs font-semibold text-primary"
-                )
+        with ui.card().classes("w-full p-0"):
+            # ── Header ──────────────────────────────
+            with ui.row().classes("w-full items-center justify-between px-4 pt-3 pb-2"):
                 with ui.row().classes("items-center gap-2"):
-                    ui.label(f"page {quiz.get('page_number', '?')}").classes(
-                        "text-xs opacity-60"
+                    ui.html(f'<span class="qz-q-number">{idx + 1}</span>')
+                    ui.html(
+                        f'<span class="qz-page-chip">page {quiz.get("page_number", "?")}</span>'
                     )
-                    ui.button(
-                        icon="delete",
-                        on_click=lambda _e, i=idx: delete_quiz(i),
-                    ).props("flat dense round color=negative").tooltip(
-                        "Remove this question"
-                    )
+                ui.button(
+                    icon="delete",
+                    on_click=lambda *_, i=idx: delete_quiz(i),
+                ).props("flat dense round color=negative").tooltip(
+                    "Remove this question"
+                )
+            ui.separator().style("margin: 0; opacity: 0.15")
 
-            ui.input(
-                label="Question",
-                value=quiz.get("question", ""),
-            ).classes("w-full qz-question").props("outlined dense").on_value_change(
-                lambda e, q=quiz: q.update(question=e.value)
-            )
-
-            with ui.row().classes("w-full flex-wrap gap-2"):
-                for letter in ("a", "b", "c", "d"):
-                    ui.input(
-                        label=f"Option {letter.upper()}",
-                        value=quiz.get(f"option_{letter}", ""),
-                    ).style("flex: 1 1 10rem").props("outlined dense").on_value_change(
-                        lambda e, q=quiz, k=f"option_{letter}": q.update({k: e.value})
-                    )
-
-            with ui.row().classes("w-full items-center gap-3"):
-                ui.label("Correct").classes("text-xs opacity-70")
-                ui.radio(
-                    ["A", "B", "C", "D"],
-                    value=quiz.get("answer", "A"),
-                ).props("inline dense color=primary").on_value_change(
-                    lambda e, q=quiz: q.update(answer=e.value)
+            # ── Question + Options + Answer ──────────
+            with ui.column().classes("w-full gap-3 px-4 pt-3 pb-3"):
+                ui.input(
+                    label="Question",
+                    value=quiz.get("question", ""),
+                ).classes(
+                    "w-full qz-question"
+                ).props("outlined dense").on_value_change(
+                    lambda e, q=quiz: q.update(question=e.value)
                 )
 
-            ui.textarea(
-                label="Explanation",
-                value=quiz.get("explanation", ""),
-            ).classes("w-full").props("outlined dense autogrow").on_value_change(
-                lambda e, q=quiz: q.update(explanation=e.value)
-            )
+                ui.html('<div class="qz-options-label">Options</div>')
+                for letter in ("a", "b", "c", "d"):
+                    with ui.row().classes("items-center gap-2 w-full"):
+                        ui.html(
+                            f'<span class="qz-option-letter">{letter.upper()}</span>'
+                        )
+                        ui.input(
+                            value=quiz.get(f"option_{letter}", ""),
+                        ).classes(
+                            "flex-1"
+                        ).props("outlined dense").on_value_change(
+                            lambda e, q=quiz, k=f"option_{letter}": q.update(
+                                {k: e.value}
+                            )
+                        )
+
+                ui.separator().style("margin: 2px 0; opacity: 0.10")
+                with ui.row().classes("items-center gap-3 flex-wrap"):
+                    ui.html('<span class="qz-answer-label">Correct answer</span>')
+                    ui.radio(
+                        ["A", "B", "C", "D"],
+                        value=quiz.get("answer", "A"),
+                    ).props("inline dense color=primary").on_value_change(
+                        lambda e, q=quiz: q.update(answer=e.value)
+                    )
+
+            # ── Explanation (collapsible) ────────────
+            ui.separator().style("margin: 0; opacity: 0.10")
+            with (
+                ui.expansion("Explanation", icon="lightbulb_outline")
+                .classes("w-full")
+                .props("dense")
+            ):
+                with ui.column().classes("px-4 pb-3 pt-1 w-full"):
+                    ui.textarea(
+                        value=quiz.get("explanation", ""),
+                    ).classes(
+                        "w-full"
+                    ).props("outlined dense autogrow").on_value_change(
+                        lambda e, q=quiz: q.update(explanation=e.value)
+                    )
 
     # ============================================================
     # Handlers
@@ -462,9 +530,7 @@ def index() -> None:
 
     def reset_all() -> None:
         if state["running"]:
-            ui.notify(
-                "Generation in progress — wait for it to finish", type="warning"
-            )
+            ui.notify("Generation in progress — wait for it to finish", type="warning")
             return
         if state["pdf_path"]:
             Path(state["pdf_path"]).unlink(missing_ok=True)
@@ -536,9 +602,7 @@ def index() -> None:
 
             def toggle_dark() -> None:
                 dark.toggle()
-                dark_btn.props(
-                    f"icon={'light_mode' if dark.value else 'dark_mode'}"
-                )
+                dark_btn.props(f"icon={'light_mode' if dark.value else 'dark_mode'}")
 
             dark_btn = (
                 ui.button(icon="light_mode", on_click=toggle_dark)
@@ -582,8 +646,9 @@ def index() -> None:
 
                 key_links = {
                     provider: (
-                        ui.link("Get an API key →", PROVIDER_KEY_URL[provider], new_tab=True)
-                        .classes("text-xs text-primary")
+                        ui.link(
+                            "Get an API key →", PROVIDER_KEY_URL[provider], new_tab=True
+                        ).classes("text-xs text-primary")
                     )
                     for provider in PROVIDERS
                 }
@@ -610,16 +675,16 @@ def index() -> None:
 
         # --- upload ---
         with ui.card().classes("w-full p-4"):
-            ui.html('<div class="qz-step-row"><span class="qz-step-badge">1</span><span class="qz-step-label">Upload PDF</span></div>')
+            ui.html(
+                '<div class="qz-step-row"><span class="qz-step-badge">1</span><span class="qz-step-label">Upload PDF</span></div>'
+            )
             ui.upload(
                 label="Drop your PDF here, or click to browse",
                 auto_upload=True,
                 multiple=False,
                 on_upload=on_upload,
             ).props('accept=".pdf" color=primary').classes("w-full")
-            upload_status = ui.label("No file selected").classes(
-                "text-xs opacity-50"
-            )
+            upload_status = ui.label("No file selected").classes("text-xs opacity-50")
 
         # --- generate / reset / cancel ---
         @ui.refreshable
@@ -638,7 +703,9 @@ def index() -> None:
                         on_click=reset_all,
                     ).props("flat color=primary")
 
-        ui.html('<div class="qz-step-row" style="margin-top:4px"><span class="qz-step-badge">2</span><span class="qz-step-label">Generate</span></div>')
+        ui.html(
+            '<div class="qz-step-row" style="margin-top:4px"><span class="qz-step-badge">2</span><span class="qz-step-label">Generate</span></div>'
+        )
         generate_btn = ui.button(
             "Generate Quiz",
             icon="play_arrow",

--- a/src/ui/app.py
+++ b/src/ui/app.py
@@ -6,6 +6,7 @@ import os
 import tempfile
 from pathlib import Path
 from typing import IO, Any
+from uuid import uuid4
 
 from nicegui import app, events, ui
 
@@ -434,12 +435,12 @@ def index() -> None:
                             lambda e, q=quiz: q.update(answer=e.value)
                         )
 
-            if state["quiz_mode"] and idx not in state["revealed"]:
+            if state["quiz_mode"] and quiz.get("_id") not in state["revealed"]:
                 # ── Quiz mode: hide answer + explanation ──
                 ui.separator().style("margin: 0; opacity: 0.10")
                 with ui.row().classes("px-4 py-3 w-full justify-center"):
-                    def _reveal(i: int = idx) -> None:
-                        state["revealed"].add(i)
+                    def _reveal(qid: str = quiz["_id"]) -> None:
+                        state["revealed"].add(qid)
                         cards_view.refresh()
                     ui.button("Reveal answer", icon="visibility", on_click=_reveal).props(
                         "flat color=primary dense"
@@ -500,7 +501,7 @@ def index() -> None:
         def push(snapshot: GenerationProgress) -> None:
             state["progress"] = snapshot
             if snapshot.phase in ("done", "error"):
-                state["quizzes"] = [dict(q) for q in snapshot.quizzes]
+                state["quizzes"] = [{**dict(q), "_id": uuid4().hex} for q in snapshot.quizzes]
             progress_view.refresh()
 
         try:

--- a/src/ui/app.py
+++ b/src/ui/app.py
@@ -260,6 +260,8 @@ def index() -> None:
         "page": 0,
         "page_size": 10,
         "cancel_event": None,
+        "quiz_mode": False,
+        "revealed": set(),
     }
 
     # ============================================================
@@ -269,6 +271,8 @@ def index() -> None:
     @ui.refreshable
     def progress_view() -> None:
         p: GenerationProgress = state["progress"]
+        if p.phase == "idle":
+            return
         with ui.card().classes("w-full p-4"):
             with ui.row().classes("items-center gap-2"):
                 ui.icon(_PHASE_ICON.get(p.phase, "radio_button_unchecked")).classes(
@@ -306,17 +310,32 @@ def index() -> None:
     @ui.refreshable
     def cards_view() -> None:
         quizzes: list[dict] = state["quizzes"]
+
+        def toggle_quiz_mode() -> None:
+            state["quiz_mode"] = not state["quiz_mode"]
+            if not state["quiz_mode"]:
+                state["revealed"] = set()
+            cards_view.refresh()
+
         with ui.row().classes("w-full items-center justify-between"):
             ui.html(
                 f'<div class="qz-step-row" style="margin-bottom:0"><span class="qz-step-badge">3</span><span class="qz-step-label">Review &amp; Download ({len(quizzes)})</span></div>'
             )
-            download_btn = ui.button(
-                "Download CSV",
-                icon="download",
-                on_click=on_download,
-            ).props("color=primary unelevated")
-            if not quizzes:
-                download_btn.disable()
+            with ui.row().classes("items-center gap-2"):
+                quiz_mode_btn = ui.button(
+                    "Exit Quiz Mode" if state["quiz_mode"] else "Quiz Mode",
+                    icon="edit_note" if state["quiz_mode"] else "school",
+                    on_click=toggle_quiz_mode,
+                ).props("flat color=primary")
+                if not quizzes:
+                    quiz_mode_btn.disable()
+                download_btn = ui.button(
+                    "Download CSV",
+                    icon="download",
+                    on_click=on_download,
+                ).props("color=primary unelevated")
+                if not quizzes:
+                    download_btn.disable()
 
         if not quizzes:
             with ui.column().classes("qz-empty w-full"):
@@ -414,21 +433,32 @@ def index() -> None:
                         lambda e, q=quiz: q.update(answer=e.value)
                     )
 
-            # ── Explanation (collapsible) ────────────
-            ui.separator().style("margin: 0; opacity: 0.10")
-            with (
-                ui.expansion("Explanation", icon="lightbulb_outline")
-                .classes("w-full")
-                .props("dense")
-            ):
-                with ui.column().classes("px-4 pb-3 pt-1 w-full"):
-                    ui.textarea(
-                        value=quiz.get("explanation", ""),
-                    ).classes(
-                        "w-full"
-                    ).props("outlined dense autogrow").on_value_change(
-                        lambda e, q=quiz: q.update(explanation=e.value)
+            if state["quiz_mode"] and idx not in state["revealed"]:
+                # ── Quiz mode: hide answer + explanation ──
+                ui.separator().style("margin: 0; opacity: 0.10")
+                with ui.row().classes("px-4 py-3 w-full justify-center"):
+                    def _reveal(i: int = idx) -> None:
+                        state["revealed"].add(i)
+                        cards_view.refresh()
+                    ui.button("Reveal answer", icon="visibility", on_click=_reveal).props(
+                        "flat color=primary dense"
                     )
+            else:
+                # ── Explanation (collapsible) ────────────
+                ui.separator().style("margin: 0; opacity: 0.10")
+                with (
+                    ui.expansion("Explanation", icon="lightbulb_outline")
+                    .classes("w-full")
+                    .props("dense")
+                ):
+                    with ui.column().classes("px-4 pb-3 pt-1 w-full"):
+                        ui.textarea(
+                            value=quiz.get("explanation", ""),
+                        ).classes(
+                            "w-full"
+                        ).props("outlined dense autogrow").on_value_change(
+                            lambda e, q=quiz: q.update(explanation=e.value)
+                        )
 
     # ============================================================
     # Handlers
@@ -454,6 +484,8 @@ def index() -> None:
 
         provider_chip.set_text(f"provider: {state['provider']}")
 
+        state["quiz_mode"] = False
+        state["revealed"] = set()
         state["running"] = True
         state["quizzes"] = []
         state["page"] = 0

--- a/src/ui/app.py
+++ b/src/ui/app.py
@@ -244,7 +244,7 @@ def index() -> None:
         accent=GREEN_ACCENT,
         positive=GREEN_PRIMARY,
     )
-    dark = ui.dark_mode(value=False)
+    dark = ui.dark_mode(value=app.storage.user.get("dark_mode", False))
     ui.add_head_html(HEAD_CSS)
 
     state: dict[str, Any] = {
@@ -423,15 +423,16 @@ def index() -> None:
                             )
                         )
 
-                ui.separator().style("margin: 2px 0; opacity: 0.10")
-                with ui.row().classes("items-center gap-3 flex-wrap"):
-                    ui.html('<span class="qz-answer-label">Correct answer</span>')
-                    ui.radio(
-                        ["A", "B", "C", "D"],
-                        value=quiz.get("answer", "A"),
-                    ).props("inline dense color=primary").on_value_change(
-                        lambda e, q=quiz: q.update(answer=e.value)
-                    )
+                if not state["quiz_mode"] or idx in state["revealed"]:
+                    ui.separator().style("margin: 2px 0; opacity: 0.10")
+                    with ui.row().classes("items-center gap-3 flex-wrap"):
+                        ui.html('<span class="qz-answer-label">Correct answer</span>')
+                        ui.radio(
+                            ["A", "B", "C", "D"],
+                            value=quiz.get("answer", "A"),
+                        ).props("inline dense color=primary").on_value_change(
+                            lambda e, q=quiz: q.update(answer=e.value)
+                        )
 
             if state["quiz_mode"] and idx not in state["revealed"]:
                 # ── Quiz mode: hide answer + explanation ──
@@ -634,6 +635,7 @@ def index() -> None:
 
             def toggle_dark() -> None:
                 dark.toggle()
+                app.storage.user["dark_mode"] = dark.value
                 dark_btn.props(f"icon={'light_mode' if dark.value else 'dark_mode'}")
 
             dark_btn = (
@@ -767,6 +769,7 @@ def main() -> None:
         reload=False,
         show=False,
         favicon="🎓",
+        storage_secret=os.environ.get("STORAGE_SECRET", "quizzer-ui-local"),
     )
 
 

--- a/src/ui/app.py
+++ b/src/ui/app.py
@@ -34,6 +34,134 @@ GREEN_PRIMARY = "#16a34a"
 GREEN_DARK = "#15803d"
 GREEN_ACCENT = "#22c55e"
 
+# Hallmark · genre: playful · macrostructure: Narrative Workflow · theme: Plume
+# contrast: pass · nav: app-header · footer: none (tool UI)
+HEAD_CSS = """
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+<style>
+:root {
+  --font-ui: 'Outfit', system-ui, sans-serif;
+  --radius-card: 14px;
+  --radius-input: 8px;
+  --radius-btn:  8px;
+  --dur-hover: 160ms;
+  --ease-out: cubic-bezier(0.0, 0.0, 0.2, 1.0);
+}
+.body--dark {
+  --color-paper:   oklch(14% 0.008 142);
+  --color-paper-2: oklch(19% 0.010 142);
+  --color-paper-3: oklch(24% 0.010 142);
+  --color-rule:    oklch(30% 0.008 142);
+  --color-muted:   oklch(55% 0.008 142);
+  --color-ink:     oklch(94% 0.005 100);
+  --color-shadow:  oklch(0% 0 0 / 0.45);
+}
+.body--light {
+  --color-paper:   oklch(97% 0.008 142);
+  --color-paper-2: oklch(93% 0.010 142);
+  --color-paper-3: oklch(89% 0.012 142);
+  --color-rule:    oklch(82% 0.008 142);
+  --color-muted:   oklch(48% 0.008 142);
+  --color-ink:     oklch(18% 0.010 142);
+  --color-shadow:  oklch(0% 0 0 / 0.10);
+}
+
+/* ── Base ──────────────────────────────────── */
+body, .q-app { font-family: var(--font-ui) !important; }
+
+/* ── Page background ───────────────────────── */
+.body--dark .q-page-container,
+.body--dark .q-page { background: var(--color-paper) !important; }
+.body--light .q-page-container,
+.body--light .q-page { background: var(--color-paper) !important; }
+
+/* ── Cards ─────────────────────────────────── */
+.q-card {
+  border-radius: var(--radius-card) !important;
+  background: var(--color-paper-2) !important;
+  box-shadow: 0 2px 12px -2px var(--color-shadow),
+              0 0 0 1px oklch(100% 0 0 / 0.06) !important;
+  transition: box-shadow var(--dur-hover) var(--ease-out),
+              transform var(--dur-hover) var(--ease-out) !important;
+}
+.q-card:hover {
+  box-shadow: 0 6px 24px -4px var(--color-shadow),
+              0 0 0 1px oklch(100% 0 0 / 0.09) !important;
+  transform: translateY(-1px) !important;
+}
+
+/* ── Header ─────────────────────────────────── */
+.body--dark .q-header {
+  background: linear-gradient(120deg,
+    oklch(30% 0.17 142), oklch(24% 0.12 160)) !important;
+  border-bottom: 1px solid oklch(100% 0 0 / 0.08) !important;
+  box-shadow: none !important;
+}
+.body--light .q-header {
+  background: linear-gradient(120deg,
+    oklch(48% 0.17 142), oklch(40% 0.14 160)) !important;
+  border-bottom: 1px solid oklch(0% 0 0 / 0.12) !important;
+  box-shadow: none !important;
+}
+
+/* ── Drawer ─────────────────────────────────── */
+.body--dark .q-drawer {
+  background: oklch(16% 0.009 142) !important;
+  border-right: 1px solid var(--color-rule) !important;
+}
+.body--light .q-drawer {
+  background: var(--color-paper-2) !important;
+  border-right: 1px solid var(--color-rule) !important;
+}
+
+/* ── Inputs ─────────────────────────────────── */
+.q-field--outlined .q-field__control {
+  border-radius: var(--radius-input) !important;
+}
+
+/* ── Buttons ────────────────────────────────── */
+.q-btn:not(.q-btn--round) {
+  border-radius: var(--radius-btn) !important;
+  font-family: var(--font-ui) !important;
+  font-weight: 600 !important;
+}
+
+/* ── Progress bar ───────────────────────────── */
+.q-linear-progress { height: 6px !important; border-radius: 999px !important; overflow: hidden !important; }
+.q-linear-progress__track, .q-linear-progress__model { border-radius: 999px !important; }
+
+/* ── Upload zone ────────────────────────────── */
+.q-uploader { border-radius: var(--radius-card) !important; }
+.q-uploader__header { border-radius: var(--radius-card) var(--radius-card) 0 0 !important; }
+
+/* ── Step badge ─────────────────────────────── */
+.qz-step-row { display: flex; align-items: center; gap: 8px; margin-bottom: 10px; }
+.qz-step-badge {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 22px; height: 22px; border-radius: 50%;
+  background: var(--q-primary, #16a34a); color: #fff;
+  font-size: 11px; font-weight: 800; font-family: var(--font-ui);
+  flex-shrink: 0; line-height: 1;
+}
+.qz-step-label {
+  font-size: 11px; font-weight: 700;
+  letter-spacing: 0.07em; text-transform: uppercase; opacity: 0.65;
+}
+
+/* ── Quiz question prominence ───────────────── */
+.qz-question .q-field__native,
+.qz-question .q-field__input { font-size: 14px !important; font-weight: 600 !important; line-height: 1.55 !important; }
+
+/* ── Empty state ────────────────────────────── */
+.qz-empty {
+  display: flex; flex-direction: column; align-items: center;
+  gap: 8px; padding: 48px 24px; text-align: center; opacity: 0.5;
+}
+</style>
+"""
+
 
 def is_valid_pdf(content: IO[bytes]) -> bool:
     """Check if file content starts with the PDF magic bytes."""
@@ -47,16 +175,28 @@ def _model_for(provider: str) -> str:
     return getattr(settings, field, "") if field else ""
 
 
+_PHASE_ICON = {
+    "idle": "radio_button_unchecked",
+    "ingesting": "picture_as_pdf",
+    "chunking": "segment",
+    "generating": "auto_awesome",
+    "aggregating": "check_circle_outline",
+    "done": "check_circle",
+    "error": "error_outline",
+}
+_PHASE_TEXT = {
+    "idle": "Ready",
+    "ingesting": "Reading PDF…",
+    "chunking": "Splitting into chunks…",
+    "generating": "Generating quiz…",
+    "aggregating": "Finalizing…",
+    "done": "Done",
+    "error": "Generation failed",
+}
+
+
 def _phase_label(p: GenerationProgress) -> str:
-    return {
-        "idle": "Ready",
-        "ingesting": "Reading PDF…",
-        "chunking": "Splitting into chunks…",
-        "generating": "Generating quiz…",
-        "aggregating": "Finalizing…",
-        "done": "Done",
-        "error": "Failed",
-    }.get(p.phase, "Ready")
+    return _PHASE_TEXT.get(p.phase, "Ready")
 
 
 @ui.page("/")
@@ -67,7 +207,8 @@ def index() -> None:
         accent=GREEN_ACCENT,
         positive=GREEN_PRIMARY,
     )
-    dark = ui.dark_mode(value=True)
+    dark = ui.dark_mode(value=False)
+    ui.add_head_html(HEAD_CSS)
 
     state: dict[str, Any] = {
         "pdf_path": None,
@@ -92,7 +233,11 @@ def index() -> None:
     def progress_view() -> None:
         p: GenerationProgress = state["progress"]
         with ui.card().classes("w-full p-4"):
-            ui.label(_phase_label(p)).classes("text-sm font-semibold text-primary")
+            with ui.row().classes("items-center gap-2"):
+                ui.icon(_PHASE_ICON.get(p.phase, "radio_button_unchecked")).classes(
+                    "text-base text-primary"
+                )
+                ui.label(_phase_label(p)).classes("text-sm font-semibold text-primary")
 
             if p.phase in ("ingesting", "chunking"):
                 ui.linear_progress(show_value=False).props(
@@ -125,9 +270,7 @@ def index() -> None:
     def cards_view() -> None:
         quizzes: list[dict] = state["quizzes"]
         with ui.row().classes("w-full items-center justify-between"):
-            ui.label(f"Generated questions ({len(quizzes)})").classes(
-                "text-sm font-semibold text-primary"
-            )
+            ui.html(f'<div class="qz-step-row" style="margin-bottom:0"><span class="qz-step-badge">3</span><span class="qz-step-label">Review &amp; Download ({len(quizzes)})</span></div>')
             download_btn = ui.button(
                 "Download CSV",
                 icon="download",
@@ -137,9 +280,10 @@ def index() -> None:
                 download_btn.disable()
 
         if not quizzes:
-            ui.label(
-                "Upload a PDF and click Generate to see questions here."
-            ).classes("text-xs opacity-60")
+            with ui.column().classes("qz-empty w-full"):
+                ui.icon("auto_stories").classes("text-5xl")
+                ui.label("No questions yet").classes("text-sm font-semibold")
+                ui.label("Upload a PDF and hit Generate to get started.").classes("text-xs")
             return
 
         page = state["page"]
@@ -189,7 +333,7 @@ def index() -> None:
             ui.input(
                 label="Question",
                 value=quiz.get("question", ""),
-            ).classes("w-full").props("outlined dense").on_value_change(
+            ).classes("w-full qz-question").props("outlined dense").on_value_change(
                 lambda e, q=quiz: q.update(question=e.value)
             )
 
@@ -466,11 +610,9 @@ def index() -> None:
 
         # --- upload ---
         with ui.card().classes("w-full p-4"):
-            ui.label("1. Upload PDF").classes(
-                "text-sm font-semibold text-primary"
-            )
+            ui.html('<div class="qz-step-row"><span class="qz-step-badge">1</span><span class="qz-step-label">Upload PDF</span></div>')
             ui.upload(
-                label="Drop a PDF here or click to browse",
+                label="Drop your PDF here, or click to browse",
                 auto_upload=True,
                 multiple=False,
                 on_upload=on_upload,
@@ -496,6 +638,7 @@ def index() -> None:
                         on_click=reset_all,
                     ).props("flat color=primary")
 
+        ui.html('<div class="qz-step-row" style="margin-top:4px"><span class="qz-step-badge">2</span><span class="qz-step-label">Generate</span></div>')
         generate_btn = ui.button(
             "Generate Quiz",
             icon="play_arrow",
@@ -519,7 +662,7 @@ def main() -> None:
         title="Quizzer",
         host="0.0.0.0",
         port=int(os.environ.get("PORT", 8080)),
-        dark=True,
+        dark=False,
         reload=False,
         show=False,
         favicon="🎓",

--- a/src/ui/app.py
+++ b/src/ui/app.py
@@ -755,6 +755,8 @@ def index() -> None:
 
 
 def main() -> None:
+    from dotenv import load_dotenv
+    load_dotenv()
     configure_logging()
     app.on_startup(lambda: logger.info("Quizzer UI started"))
     ui.run(


### PR DESCRIPTION
## Summary

- **Quiz Mode toggle** — button in the Review & Download header switches to quiz mode, hiding all answers and explanations. Each card shows a "Reveal answer" button instead. Revealed state resets when toggling off or re-generating.
- **Redesigned quiz question cards** — cleaner layout with numbered badge, page chip, letter-pill options, and collapsible explanation.
- **Light mode as default** — app now starts in light mode.
- **Progress panel hidden when idle** — the progress card no longer renders on initial load; it only appears once generation is in progress.

## Test plan

- [x] Upload a PDF and generate questions
- [x] Click **Quiz Mode** — all answer rows replaced by "Reveal answer" buttons; button label flips to "Exit Quiz Mode"
- [x] Click "Reveal answer" on one card — only that card reveals; others stay hidden
- [x] Click **Exit Quiz Mode** — all cards return to full edit view with answers visible
- [x] While in quiz mode, click Generate — quiz mode exits automatically, all cards show normally
- [x] With no quizzes loaded, confirm Quiz Mode button is disabled
- [x] On initial page load, confirm the progress card is absent; confirm it appears during generation
- [x] Toggle dark/light mode and confirm cards, header, and drawer look correct in both